### PR TITLE
Adding a gradlew step for Android builds

### DIFF
--- a/bin/newclear.sh
+++ b/bin/newclear.sh
@@ -10,6 +10,7 @@ rm -rf ios/build/ModuleCache/*
 # android
 rm -rf android/app/build
 rm -rf $HOME/.gradle/caches/
+cd android/ && ./gradlew clean && cd ..
 
 # javascript
 rm -rf node_modules/


### PR DESCRIPTION
A small extra step for Android that got React-Native actually able to build and run after a lot of headaches!